### PR TITLE
Close Information Bubble and Reset Icon to Original State on esc KeyPress

### DIFF
--- a/src/components/ui/BaseMap.vue
+++ b/src/components/ui/BaseMap.vue
@@ -100,7 +100,7 @@ export default class BaseMap extends Vue {
         lng: this.long
       }
     });
-
+    window.addEventListener("keydown", this.handleEscapeKeyPress);
     window.addEventListener("resize", this.onResize);
 
     // @ts-ignore: H is not defined
@@ -125,6 +125,15 @@ export default class BaseMap extends Vue {
   public onResize() {
     // @ts-ignore
     this.map.getViewPort().resize();
+  }
+
+  public handleEscapeKeyPress(evt: KeyboardEvent) {
+    const key = evt.keyCode || evt.key;
+    const isEscapeKey = key === 27;
+    if (isEscapeKey) {
+      this.clearOpenInformationBubble();
+      this.resetIconToOriginalState();
+    }
   }
 
   public replaceBreakHTMLTagsWithEmptySpace(str: string) {
@@ -239,6 +248,10 @@ export default class BaseMap extends Vue {
     }
   }
 
+  public resetIconToOriginalState() {
+    this.activeMarker.setIcon(this.activeIcon);
+  }
+
   public getCurrentIconAssociatedWithMarker(evt: Event) {
     this.activeIcon = ensurePossiblyNullValueReturnsObject(
       evt.target
@@ -251,7 +264,7 @@ export default class BaseMap extends Vue {
       // @ts-ignore: H is not defined
       H.ui.InfoBubble.State.CLOSED
     ) {
-      this.activeMarker.setIcon(this.activeIcon);
+      this.resetIconToOriginalState();
     }
   }
 
@@ -286,6 +299,7 @@ export default class BaseMap extends Vue {
 
   public beforeDestroy() {
     window.removeEventListener("resize", this.onResize);
+    window.removeEventListener("keydown", this.handleEscapeKeyPress);
     window.removeEventListener("tap", this.addInfoBubble);
     window.removeEventListener(
       "statechange",


### PR DESCRIPTION
#### What does this PR do?
- be able to close the information bubble using other means e.g closing the 'esc' key or clicking outside the information bubble

#### Description of Task to be completed?
- Close Information Bubble and Reset Icon to Original State on esc KeyPress
- Close Information Bubble and Reset Icon to Original State on clicking  outside it

#### How should this be manually tested?
- clone the folder
- go to branch `ft-close-info-bubble-esc-key-press-outside-bubble-click`
- enter `npm install` and `npm run serve` in your terminal respectively
- go to the home page and search for hotels in a place
- click on a marker and press the 'esc' key
- click on a marker and click outside the information bubble

#### Any background context you want to provide?
NA

#### Screenshots (if appropriate)
NA

#### Questions:
NA
