### PR TITLE
Add Online-Offline Indicator 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,12 @@
 <template>
   <div id="app">
     <notifications position="top center" />
-    <div ref="internetStatus"></div>
+    <div
+      ref="internetStatus"
+      :class="[hasInternetConnection ? 'online' : 'offline', 'internet-status']"
+    >
+      {{ internetStatusText }}
+    </div>
     <router-view />
   </div>
 </template>
@@ -11,13 +16,22 @@ import { Component, Vue } from "vue-property-decorator";
 
 @Component
 export default class App extends Vue {
-  private internetConnectionStatus = navigator.onLine;
-  public hasInternetConnection(this.internetConnectionStatus) {
-    
+  private hasInternetConnection = navigator.onLine;
+  private internetStatusText = navigator.onLine ? "Online" : "Offline";
+
+  public updateInternetConnectionStatus() {
+    this.hasInternetConnection = navigator.onLine;
+    this.internetStatusText = this.hasInternetConnection ? "Online" : "Offline";
   }
 
   mounted() {
-    const internetStatus = this.$refs.internetStatus;
+    window.addEventListener("online", this.updateInternetConnectionStatus);
+    window.addEventListener("offline", this.updateInternetConnectionStatus);
+  }
+
+  beforeDestroy() {
+    window.removeEventListener("online", this.updateInternetConnectionStatus);
+    window.removeEventListener("offline", this.updateInternetConnectionStatus);
   }
 }
 </script>
@@ -29,5 +43,26 @@ export default class App extends Vue {
   margin: 0;
   padding: 0;
   font-family: "Montserrat", sans-serif;
+}
+
+.internet-status {
+  padding: 0.2rem 1.5rem;
+  width: 90%;
+  text-align: center;
+  font-size: 1.2rem;
+  border-radius: 4px;
+  top: 5%;
+  left: 50%;
+  color: #fff;
+  transform: translate(-50%, -50%);
+  box-shadow: 0px 1px 15px rgba(63, 63, 68, 0.15);
+  position: absolute;
+}
+
+.internet-status.online {
+  background-color: #41a700;
+}
+.internet-status.offline {
+  background-color: #f15c4f;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="app">
     <notifications position="top center" />
+    <div ref="internetStatus"></div>
     <router-view />
   </div>
 </template>
@@ -9,7 +10,16 @@
 import { Component, Vue } from "vue-property-decorator";
 
 @Component
-export default class App extends Vue {}
+export default class App extends Vue {
+  private internetConnectionStatus = navigator.onLine;
+  public hasInternetConnection(this.internetConnectionStatus) {
+    
+  }
+
+  mounted() {
+    const internetStatus = this.$refs.internetStatus;
+  }
+}
 </script>
 
 <style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <notifications position="top center" />
     <div
-      ref="internetStatus"
+      v-if="internetStatusShouldShow"
       :class="[hasInternetConnection ? 'online' : 'offline', 'internet-status']"
     >
       {{ internetStatusText }}
@@ -17,10 +17,17 @@ import { Component, Vue } from "vue-property-decorator";
 @Component
 export default class App extends Vue {
   private hasInternetConnection = navigator.onLine;
+  private internetStatusShouldShow = false;
   private internetStatusText = navigator.onLine ? "Online" : "Offline";
 
   public updateInternetConnectionStatus() {
     this.hasInternetConnection = navigator.onLine;
+    if (this.hasInternetConnection) {
+      this.internetStatusShouldShow = true;
+      setTimeout(() => (this.internetStatusShouldShow = false), 5000);
+    } else {
+      this.internetStatusShouldShow = true;
+    }
     this.internetStatusText = this.hasInternetConnection ? "Online" : "Offline";
   }
 
@@ -49,14 +56,15 @@ export default class App extends Vue {
   padding: 0.2rem 1.5rem;
   width: 90%;
   text-align: center;
-  font-size: 1.2rem;
+  font-size: 1.3rem;
   border-radius: 4px;
-  top: 5%;
+  top: 20%;
   left: 50%;
   color: #fff;
   transform: translate(-50%, -50%);
   box-shadow: 0px 1px 15px rgba(63, 63, 68, 0.15);
   position: absolute;
+  z-index: 2;
 }
 
 .internet-status.online {


### PR DESCRIPTION
#### What does this PR do?
- have online-offline indicator in the application

#### Description of Task to be completed?
- add css styles for 'offline' and 'online' status
- create online-offline indicator
- make internet status to show 'offline' status indefinitely, when offline, and 'online' status when online, for 5 seconds.

#### How should this be manually tested?
- clone the folder
- cd into the folder
- run `npm run install` and `npm run serve` respectively on the terminal
- navigate to `/` on the browser
- Disconnect internet connection to test the 'offline' status and re-connect to the internet to test the 'online' status

#### Any background context you want to provide?
- Previously, users of the application had no way to tell if they are online or not

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2020-08-18 at 11 53 33 PM" src="https://user-images.githubusercontent.com/26977462/90573468-6ac3d700-e1ae-11ea-939e-e5af65c2db52.png">
<img width="1440" alt="Screen Shot 2020-08-18 at 11 54 05 PM" src="https://user-images.githubusercontent.com/26977462/90573624-c68e6000-e1ae-11ea-9700-55fca8739ab0.png">


#### Questions:
NA
